### PR TITLE
Add support for nested properties access in GetElementAttribute command

### DIFF
--- a/WindowsUniversalAppDriver/WindowsUniversalAppDriver.InnerServer/WindowsUniversalAppDriver.InnerServer.nuspec
+++ b/WindowsUniversalAppDriver/WindowsUniversalAppDriver.InnerServer/WindowsUniversalAppDriver.InnerServer.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>WindowsUniversalAppDriver.InnerServer</id>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <authors>2GIS</authors>
     <owners>2GIS</owners>
     <projectUrl>https://github.com/2gis/windows-universal-app-driver</projectUrl>


### PR DESCRIPTION
Now you can access nested property of element using dot separated syntax in /session/:sessionId/element/:id/attribute/:name command
e.g., "SelectedItem.DisplayName", etc.