### PR TITLE
Add support for send files on the installed application

### DIFF
--- a/WindowsUniversalAppDriver/WindowsUniversalAppDriver/Automator/Capabilities.cs
+++ b/WindowsUniversalAppDriver/WindowsUniversalAppDriver/Automator/Capabilities.cs
@@ -1,5 +1,7 @@
 ﻿namespace WindowsUniversalAppDriver.Automator
 {
+    using System.Collections.Generic;
+
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
 
@@ -10,6 +12,7 @@
         internal Capabilities()
         {
             this.App = string.Empty;
+            this.Files = new Dictionary<string, string>();
             this.DeviceName = string.Empty;
             this.LaunchDelay = 0;
             this.LaunchTimeout = 10000;
@@ -32,6 +35,9 @@
 
         [JsonProperty("app")]
         public string App { get; set; }
+
+        [JsonProperty("files")]
+        public Dictionary<string, string> Files { get; set; }
 
         [JsonProperty("debugConnectToRunningApp")]
         public bool DebugConnectToRunningApp { get; set; }

--- a/WindowsUniversalAppDriver/WindowsUniversalAppDriver/CommandExecutors/CloseExecutor.cs
+++ b/WindowsUniversalAppDriver/WindowsUniversalAppDriver/CommandExecutors/CloseExecutor.cs
@@ -6,7 +6,7 @@
 
         protected override string DoImpl()
         {
-            this.Automator.Deployer.Disconnect();
+            this.Automator.Deployer.Uninstall();
 
             return null;
         }

--- a/WindowsUniversalAppDriver/WindowsUniversalAppDriver/CommandExecutors/NewSessionExecutor.cs
+++ b/WindowsUniversalAppDriver/WindowsUniversalAppDriver/CommandExecutors/NewSessionExecutor.cs
@@ -88,10 +88,12 @@
         private string InitializeApplication(bool debugDoNotDeploy = false)
         {
             var appPath = this.Automator.ActualCapabilities.App;
-            this.Automator.Deployer = new Deployer81(this.Automator.ActualCapabilities.DeviceName);
+            this.Automator.Deployer = new Deployer81(this.Automator.ActualCapabilities.DeviceName, appPath);
             if (!debugDoNotDeploy)
             {
-                this.Automator.Deployer.Deploy(appPath);
+                this.Automator.Deployer.Install();
+                this.Automator.Deployer.SendFiles(this.Automator.ActualCapabilities.Files);
+                this.Automator.Deployer.Launch();
             }
 
             this.Automator.ActualCapabilities.DeviceName = this.Automator.Deployer.DeviceName;

--- a/WindowsUniversalAppDriver/WindowsUniversalAppDriver/EmulatorHelpers/IDeployer.cs
+++ b/WindowsUniversalAppDriver/WindowsUniversalAppDriver/EmulatorHelpers/IDeployer.cs
@@ -1,5 +1,7 @@
 ﻿namespace WindowsUniversalAppDriver.EmulatorHelpers
 {
+    using System.Collections.Generic;
+
     internal interface IDeployer
     {
         #region Public Properties
@@ -10,9 +12,17 @@
 
         #region Public Methods and Operators
 
-        void Deploy(string appPath);
+        void Install();
 
-        void Disconnect();
+        void SendFiles(Dictionary<string, string> files);
+
+        void ReciveFiles(Dictionary<string, string> files);
+
+        void Launch();
+
+        void Terminate();
+
+        void Uninstall();
 
         #endregion
     }

--- a/WindowsUniversalAppDriver/WindowsUniversalAppDriver/WindowsUniversalAppDriver.csproj
+++ b/WindowsUniversalAppDriver/WindowsUniversalAppDriver/WindowsUniversalAppDriver.csproj
@@ -41,6 +41,8 @@
     <Reference Include="Microsoft.Phone.Tools.Deploy">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Microsoft SDKs\Windows Phone\v8.1\Tools\AppDeploy\Microsoft.Phone.Tools.Deploy.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.SmartDevice.Connectivity.Interface, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.SmartDevice.MultiTargeting.Connectivity, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Xde.Common, Version=8.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Microsoft XDE\8.1\Microsoft.Xde.Common.dll</HintPath>


### PR DESCRIPTION
Now you can send files to application after installation and before launch. Use 'files' capability which is a dictionary. Each key of the dictionary is "local file path", each corresponding value is "remote file path".
Need installed Windows Phone SDK 8.1